### PR TITLE
DO NOT MERGE - Optional metadata.id in Invoice

### DIFF
--- a/couchapp.js
+++ b/couchapp.js
@@ -68,6 +68,14 @@ ddoc.views.watchedPayments = {
   }
 };
 
+ddoc.views.invoiceMetadataId = {
+ map: function(doc) {
+   if (doc.type === 'invoice' && doc.metadata && doc.metadata.id) {
+     emit(doc.metadata.id, doc);
+   }
+ }
+};
+
 ddoc.views.lastBlockHash = {
   map: function(doc) {
     if (doc.type === 'blockhash') {

--- a/routes/invoices.js
+++ b/routes/invoices.js
@@ -86,6 +86,7 @@ var invoices = function(app) {
           res.end();
         }
         else {
+          console.log('invoiceData:' + require('util').inspect(invoiceData));
           res.json(invoiceData);
         }
       });


### PR DESCRIPTION
REVIEW ONLY.

resolves #26
If invoice.metadata.id exists in the database, all subsequent invoice creation with the same ID returns
the previously created invoice instead of creating a new invoice.

TODO:
- Remove debug log statements.
- Extend the expiration time of a reused unpaid invoice to whatever is specified by the new invoice call.
- Pass metadata within the callback webhooks (like 'paid')
